### PR TITLE
Make keycloak deployment role-based

### DIFF
--- a/deploykeycloak.yml
+++ b/deploykeycloak.yml
@@ -15,5 +15,8 @@
   run_once: True
   roles:
     - traefik_deployment
-      
 
+- hosts: docker_swarm_managers
+  run_one: True
+  roles:
+    - keycloak_clustered_deployment

--- a/deploykeycloak.yml
+++ b/deploykeycloak.yml
@@ -17,6 +17,6 @@
     - traefik_deployment
 
 - hosts: docker_swarm_managers
-  run_one: True
+  run_once: True
   roles:
     - keycloak_clustered_deployment

--- a/roles/docker_stack_create/defaults/main/docker_stack_create_defaults.yml
+++ b/roles/docker_stack_create/defaults/main/docker_stack_create_defaults.yml
@@ -39,6 +39,7 @@ service_imbude_defaults:
       auth: FALSE
       https: TRUE
       redirect_http: TRUE
+      sticky_loadbalance: FALSE
 
 #compose: "file or dict"
 compose_storage_folder: "~/ansible-run/compose-store"

--- a/roles/docker_stack_create/templates/traefik-compose.yml.j2
+++ b/roles/docker_stack_create/templates/traefik-compose.yml.j2
@@ -18,6 +18,7 @@ services:
         {% else %}
         - 'traefik.http.routers.{{route_name}}-ext.service={{route_name}}-ext-srv'
         - 'traefik.http.services.{{route_name}}-ext-srv.loadbalancer.server.port={{route.service_port | default(service_imbude_defaults.traefik.defaults.service_port)}}'
+        - 'traefik.http.services.{{route_name}}-ext-srv.loadbalancer.sticky={{route.sticky_loadbalance | default(service_imbude_defaults.traefik.defaults.sticky_loadbalance)}}'
         {% endif %}
         {% endfor %}
   {% endfor %}

--- a/roles/docker_stack_create/templates/traefik-compose.yml.j2
+++ b/roles/docker_stack_create/templates/traefik-compose.yml.j2
@@ -11,6 +11,7 @@ services:
     deploy:
       labels:
         {% for route_name, route in routes.items() %}
+        - 'traefik.docker.network=traefik'
         - 'traefik.http.routers.{{route_name}}-ext.rule={{route.route_rule}}'
         {% if route.service_override is defined %}
         - 'traefik.http.routers.{{route_name}}-ext.service={{route.service_override}}'

--- a/roles/docker_stack_create/templates/traefik-compose.yml.j2
+++ b/roles/docker_stack_create/templates/traefik-compose.yml.j2
@@ -11,7 +11,6 @@ services:
     deploy:
       labels:
         {% for route_name, route in routes.items() %}
-        - 'traefik.docker.network=traefik'
         - 'traefik.http.routers.{{route_name}}-ext.rule={{route.route_rule}}'
         {% if route.service_override is defined %}
         - 'traefik.http.routers.{{route_name}}-ext.service={{route.service_override}}'

--- a/roles/keycloak_clustered_deployment/defaults/main.yml
+++ b/roles/keycloak_clustered_deployment/defaults/main.yml
@@ -1,9 +1,11 @@
 ---
 # Name of the keycloak stack, used for Docker container naming and the postgres storage path
 keycloak_stack_name: keycloak
-# Name given to the traefik stack
-traefik_stack_name: '{{keycloak_stack_name}}_traefik'
-# Name of the network which connects all services for Keycloak
+# Name of the traefik stack
+traefik_stack_name: '{{keycloak_stack_name}}-traefik'
+# Rule used for matching traefik's control panel
+traefik_external_rule: "Host(`{{traefik_stack_name}}.{{core_domain_name}}`)"
+# Name of the network to use for traefik's connection to containers
 traefik_docker_network: "{{traefik_stack_name}}"
 # The external port to expose for Postgres
 postgres_external_port: 5432

--- a/roles/keycloak_clustered_deployment/defaults/main.yml
+++ b/roles/keycloak_clustered_deployment/defaults/main.yml
@@ -1,9 +1,13 @@
 ---
-# Name of the keycloak container, used for Docker container naming and the postgres storage path
-keycloak_container_name: keycloak
+# Name of the keycloak stack, used for Docker container naming and the postgres storage path
+keycloak_stack_name: keycloak
+# Name given to the traefik stack
+traefik_stack_name: '{{keycloak_stack_name}}_traefik'
+# Name of the network which connects all services for Keycloak
+traefik_docker_network: "{{traefik_stack_name}}"
 # The external port to expose for Postgres
 postgres_external_port: 5432
 # The directory in which to mount the data directory from Postgres
-postgres_data_directory: /etc/postgres-storage/{{ keycloak_container_name }}
+postgres_data_directory: /etc/postgres-storage/{{ keycloak_stack_name }}
 # The URL that is used for the base of all routes for Keycloak
 keycloak_frontend_url: "http://localhost:8080/auth"

--- a/roles/keycloak_clustered_deployment/defaults/main.yml
+++ b/roles/keycloak_clustered_deployment/defaults/main.yml
@@ -1,12 +1,6 @@
 ---
 # Name of the keycloak stack, used for Docker container naming and the postgres storage path
 keycloak_stack_name: keycloak
-# Name of the traefik stack
-traefik_stack_name: '{{keycloak_stack_name}}-traefik'
-# Rule used for matching traefik's control panel
-traefik_external_rule: "Host(`{{traefik_stack_name}}.{{core_domain_name}}`)"
-# Name of the network to use for traefik's connection to containers
-traefik_docker_network: "{{traefik_stack_name}}"
 # The external port to expose for Postgres
 postgres_external_port: 5432
 # The directory in which to mount the data directory from Postgres

--- a/roles/keycloak_clustered_deployment/meta/main.yml
+++ b/roles/keycloak_clustered_deployment/meta/main.yml
@@ -1,9 +1,3 @@
 dependencies:
   - docker
   - role: traefik_deployment
-    vars:
-      traefik_stack_name: '{{traefik_stack_name}}'
-      # Rule used for matching traefik's control panel
-      traefik_external_rule: 'Host(`{{traefik_stack_name}}.{{core_domain_name}}`)'
-      # Name of the network to use for traefik's connection to containers
-      traefik_docker_network: '{{traefik_stack_name}}'

--- a/roles/keycloak_clustered_deployment/meta/main.yml
+++ b/roles/keycloak_clustered_deployment/meta/main.yml
@@ -1,7 +1,3 @@
 dependencies:
   - docker
-  - role: docker_swarm_network
-    vars:
-      docker_network_name: "{{traefik_docker_network}}"
-      docker_network_driver: "overlay"
   - role: traefik_deployment

--- a/roles/keycloak_clustered_deployment/meta/main.yml
+++ b/roles/keycloak_clustered_deployment/meta/main.yml
@@ -5,6 +5,3 @@ dependencies:
       docker_network_name: "{{traefik_docker_network}}"
       docker_network_driver: "overlay"
   - role: traefik_deployment
-    vars:
-      # Rule used for matching traefik's control panel
-      traefik_external_rule: "Host(`{{traefik_stack_name}}.{{core_domain_name}}`)"

--- a/roles/keycloak_clustered_deployment/meta/main.yml
+++ b/roles/keycloak_clustered_deployment/meta/main.yml
@@ -1,3 +1,9 @@
 dependencies:
   - docker
   - role: traefik_deployment
+    vars:
+      traefik_stack_name: '{{traefik_stack_name}}'
+      # Rule used for matching traefik's control panel
+      traefik_external_rule: 'Host(`{{traefik_stack_name}}.{{core_domain_name}}`)'
+      # Name of the network to use for traefik's connection to containers
+      traefik_docker_network: '{{traefik_stack_name}}'

--- a/roles/keycloak_clustered_deployment/meta/main.yml
+++ b/roles/keycloak_clustered_deployment/meta/main.yml
@@ -1,2 +1,10 @@
 dependencies:
   - docker
+  - role: docker_swarm_network
+    vars:
+      docker_network_name: "{{traefik_docker_network}}"
+      docker_network_driver: "overlay"
+  - role: traefik_deployment
+    vars:
+      # Rule used for matching traefik's control panel
+      traefik_external_rule: "Host(`{{traefik_stack_name}}.{{core_domain_name}}`)"

--- a/roles/keycloak_clustered_deployment/tasks/main.yml
+++ b/roles/keycloak_clustered_deployment/tasks/main.yml
@@ -1,5 +1,3 @@
-# Big shoutout to my homies at DigitalOcean from which I could base the initial docker setup on
-# (https://www.digitalocean.com/community/tutorials/how-to-use-ansible-to-install-and-set-up-docker-on-ubuntu-18-04 but we're debian gang instead)
 - name: Create Postgres database storage directory
   file:
     path: '{{ postgres_data_directory }}'
@@ -10,7 +8,7 @@
   include_role:
     name: 'docker_stack_create'
   vars:
-    stack_name: '{{ keycloak_container_name }}'
+    stack_name: '{{ keycloak_stack_name }}'
     compose:
       version: "3.2"
       networks:

--- a/roles/keycloak_clustered_deployment/tasks/main.yml
+++ b/roles/keycloak_clustered_deployment/tasks/main.yml
@@ -20,8 +20,9 @@
     compose:
       version: "3.2"
       networks:
-        '{{ traefik_docker_network }}':
-          external: TRUE
+        traefik_external:
+          external:
+            name: '{{ traefik_docker_network }}'
       services:
         postgres:
           image: "{{ postgres_container_image }}"
@@ -39,7 +40,7 @@
         keycloak:
           image: '{{ keycloak_container_image }}' # See https://github.com/ivangfr/keycloak-clustered
           networks:
-            - '{{ traefik_docker_network }}'
+            - 'traefik_external'
           deploy:
             mode: global
           ports:

--- a/roles/keycloak_clustered_deployment/tasks/main.yml
+++ b/roles/keycloak_clustered_deployment/tasks/main.yml
@@ -12,10 +12,11 @@
     service_imbude:
       traefik:
         keycloak:
-          enabled: TRUE
-          route_rule: '{{ keycloak_traefik_rule }}'
-          service_port: 8080
-          sticky_loadbalance: TRUE
+          auth:
+            enabled: TRUE
+            route_rule: '{{ keycloak_traefik_rule }}'
+            service_port: 8080
+            sticky_loadbalance: TRUE
     compose:
       version: "3.2"
       services:

--- a/roles/keycloak_clustered_deployment/tasks/main.yml
+++ b/roles/keycloak_clustered_deployment/tasks/main.yml
@@ -11,10 +11,6 @@
     stack_name: '{{ keycloak_stack_name }}'
     compose:
       version: "3.2"
-      networks:
-        traefik:
-          external:
-            name: '{{ traefik_docker_network }}'
       services:
         postgres:
           image: "{{ postgres_container_image }}"

--- a/roles/keycloak_clustered_deployment/tasks/main.yml
+++ b/roles/keycloak_clustered_deployment/tasks/main.yml
@@ -19,6 +19,9 @@
             sticky_loadbalance: TRUE
     compose:
       version: "3.2"
+      networks:
+        '{{ traefik_docker_network }}':
+          external: TRUE
       services:
         postgres:
           image: "{{ postgres_container_image }}"

--- a/roles/keycloak_clustered_deployment/tasks/main.yml
+++ b/roles/keycloak_clustered_deployment/tasks/main.yml
@@ -12,7 +12,7 @@
   vars:
     stack_name: '{{ keycloak_container_name }}'
     compose:
-      version: "3"
+      version: "3.2"
       networks:
         traefik:
           external:

--- a/roles/keycloak_clustered_deployment/tasks/main.yml
+++ b/roles/keycloak_clustered_deployment/tasks/main.yml
@@ -1,9 +1,5 @@
 # Big shoutout to my homies at DigitalOcean from which I could base the initial docker setup on
 # (https://www.digitalocean.com/community/tutorials/how-to-use-ansible-to-install-and-set-up-docker-on-ubuntu-18-04 but we're debian gang instead)
-
-- name: Keycloak clustered deployment
-  hosts: docker_swarm_manager
-
 - name: Create Postgres database storage directory
   file:
     path: '{{ postgres_data_directory }}'

--- a/roles/keycloak_clustered_deployment/tasks/main.yml
+++ b/roles/keycloak_clustered_deployment/tasks/main.yml
@@ -11,11 +11,12 @@
     mode: '0740'
 
 - name: Create keycloak container stack
-  docker_stack:
-    name: '{{ keycloak_container_name }}'
-    state: present
+  include_role:
+    name: 'docker_stack_create'
+  vars:
+    stack_name: '{{ keycloak_container_name }}'
     compose:
-    - version: "3"
+      version: "3"
       networks:
         traefik:
           external:

--- a/roles/keycloak_clustered_deployment/tasks/main.yml
+++ b/roles/keycloak_clustered_deployment/tasks/main.yml
@@ -35,8 +35,6 @@
             POSTGRES_PASSWORD: '{{ postgres_password }}'
         keycloak:
           image: '{{ keycloak_container_image }}' # See https://github.com/ivangfr/keycloak-clustered
-          networks:
-            - 'traefik'
           deploy:
             mode: global
           ports:

--- a/roles/keycloak_clustered_deployment/tasks/main.yml
+++ b/roles/keycloak_clustered_deployment/tasks/main.yml
@@ -9,6 +9,13 @@
     name: 'docker_stack_create'
   vars:
     stack_name: '{{ keycloak_stack_name }}'
+    service_imbude:
+      traefik:
+        keycloak:
+          enabled: TRUE
+          route_rule: '{{ keycloak_traefik_rule }}'
+          service_port: 8080
+          sticky_loadbalance: TRUE
     compose:
       version: "3.2"
       services:
@@ -31,13 +38,6 @@
             - '{{ traefik_docker_network }}'
           deploy:
             mode: global
-            labels:
-              - 'traefik.enable=true'
-              - 'traefik.http.routers.keycloak.rule={{ keycloak_traefik_rule }}'
-              - 'traefik.http.services.keycloak-service.loadbalancer.sticky=true'
-              - 'traefik.http.services.keycloak-service.loadbalancer.server.port=8080'
-              - 'traefik.http.routers.keycloak.service=keycloak-service'
-              - 'traefik.docker.network={{ traefik_docker_network }}'
           ports:
             - '7600:7600' # Used for inter-host communications for clustered mode
           environment:

--- a/roles/keycloak_clustered_deployment/tasks/main.yml
+++ b/roles/keycloak_clustered_deployment/tasks/main.yml
@@ -19,10 +19,6 @@
             sticky_loadbalance: TRUE
     compose:
       version: "3.2"
-      networks:
-        traefik_external:
-          external:
-            name: '{{ traefik_docker_network }}'
       services:
         postgres:
           image: "{{ postgres_container_image }}"
@@ -40,7 +36,7 @@
         keycloak:
           image: '{{ keycloak_container_image }}' # See https://github.com/ivangfr/keycloak-clustered
           networks:
-            - 'traefik_external'
+            - 'traefik'
           deploy:
             mode: global
           ports:

--- a/roles/traefik_deployment/meta/main.yml
+++ b/roles/traefik_deployment/meta/main.yml
@@ -34,6 +34,7 @@ dependencies:
               - "--entrypoints.https.address=:443"
               - "--providers.docker"
               - "--providers.docker.swarmmode=true"
+              - "--providers.docker.network={{traefik_docker_network}}"
               - "--providers.file.directory=/etc/traefik/conf.d/"
               - "--providers.file.watch=true"
             volumes:


### PR DESCRIPTION
as discussed in discord, makes the keycloak deployment role-based utilizing the new role setup that MSO created

changes:
- fix traefik deployments not using the correct docker network
- add ability to specify sticky sessions for load balancing when imbuding services with stack creation role
- add role for deploying a clustered keycloak server